### PR TITLE
Add better error reporting to s3 scripts

### DIFF
--- a/s3-tasks/s3_pull.sh
+++ b/s3-tasks/s3_pull.sh
@@ -1,5 +1,8 @@
+#!/bin/bash
+set -eE -v
+trap 'echo "Last command exited with status code of $?, exiting..."' ERR
+
+test -n "$OUTPUT_DIR"
+
 /gpfs/mindphidata/cdm_repos/github/cdm-cbioportal-etl/s3-tasks/authenticate_service_account.sh private
 aws s3 cp s3://cdm-deliverable/data_clinical_sample.txt $OUTPUT_DIR --profile saml
-if [ $? -ne 0 ] ; then
-  echo "`date`: Failed to download MSK_SOLID_HEME sample list from S3, exiting..."
-fi

--- a/s3-tasks/s3_push.sh
+++ b/s3-tasks/s3_push.sh
@@ -1,5 +1,9 @@
+#!/bin/bash
+set -eE -v
+trap 'echo "Last command exited with status code of $?, exiting..."' ERR
+
+test -n "$INPUT_DIR"
+test -n "$OUTPUT_DIR"
+
 /gpfs/mindphidata/cdm_repos/github/cdm-cbioportal-etl/s3-tasks/authenticate_service_account.sh private
 aws s3 sync $INPUT_DIR s3://cdm-deliverable/$OUTPUT_DIR --profile saml
-if [ $? -ne 0 ] ; then
-  echo "`date`: Failed to upload CDM annotated data to S3 bucket, exiting..."
-fi


### PR DESCRIPTION
Use `trap` command to report error status and test that required environment variables are set