### PR TITLE
Changes to s3 pull and push scripts to work with trigger functionality

### DIFF
--- a/s3-tasks/s3_pull.sh
+++ b/s3-tasks/s3_pull.sh
@@ -2,7 +2,12 @@
 set -eE -v
 trap 'echo "Last command exited with status code of $?, exiting..."' ERR
 
+test -n "$BUCKET_NAME"
+test -n "$BUCKET_KEY"
 test -n "$OUTPUT_DIR"
 
 /gpfs/mindphidata/cdm_repos/github/cdm-cbioportal-etl/s3-tasks/authenticate_service_account.sh private
-aws s3 cp s3://cdm-deliverable/data_clinical_sample.txt $OUTPUT_DIR --profile saml
+aws s3 cp s3://$BUCKET_NAME/$BUCKET_KEY $OUTPUT_DIR --profile saml
+
+# Since the BUCKET_KEY is used as a sensor, we must remove it after downloading
+aws s3 rm s3://$BUCKET_NAME/$BUCKET_KEY

--- a/s3-tasks/s3_push.sh
+++ b/s3-tasks/s3_push.sh
@@ -3,7 +3,8 @@ set -eE -v
 trap 'echo "Last command exited with status code of $?, exiting..."' ERR
 
 test -n "$INPUT_DIR"
+test -n "$BUCKET_NAME"
 test -n "$OUTPUT_DIR"
 
 /gpfs/mindphidata/cdm_repos/github/cdm-cbioportal-etl/s3-tasks/authenticate_service_account.sh private
-aws s3 sync $INPUT_DIR s3://cdm-deliverable/$OUTPUT_DIR --profile saml
+aws s3 sync $INPUT_DIR s3://$BUCKET_NAME/$OUTPUT_DIR --profile saml


### PR DESCRIPTION
These changes correspond to the PR https://github.com/clinical-data-mining/dags/pull/15. It introduces `$BUCKET_NAME` and `$BUCKET_KEY` variables to the s3_pull and s3_push scripts.