### PR TITLE
Modify scripts to accept command line arguments

### DIFF
--- a/pipeline/bash/bash_monitor_completeness.sh
+++ b/pipeline/bash/bash_monitor_completeness.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 
-#REPO_LOCATION="/gpfs/mindphidata/cdm_repos/github/"
-
 set -e
+
+REPO_LOCATION=$1
+YAML_CONFIG=$2
+FNAME_LOG=$3
+
+test -n "$REPO_LOCATION"
+test -n "$YAML_CONFIG"
+test -n "$FNAME_LOG"
 
 # Activate virtual env
 source /gpfs/mindphidata/fongc2/miniconda3/etc/profile.d/conda.sh
@@ -10,10 +16,8 @@ conda activate conda-env-cdm
 
 # Get variables
 SCRIPT="${REPO_LOCATION}cdm-cbioportal-etl/pipeline/monitoring/monitoring_completeness.py"
-#YAML_CONFIG="${REPO_LOCATION}cdm-cbioportal-etl/config/etl_config_all_impact.yml"
 
 # Run script
 python $SCRIPT \
   --config_yaml=$YAML_CONFIG \
   --incomplete_fields_csv="$FNAME_LOG"
-

--- a/pipeline/bash/bash_save_anchor_dates.sh
+++ b/pipeline/bash/bash_save_anchor_dates.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-#REPO_LOCATION="/gpfs/mindphidata/cdm_repos/github/"
-#YAML_CONFIG="/gpfs/mindphidata/cdm_repos/github/cdm-cbioportal-etl/config/etl_config_mskimpact.yml"
-
 set -e
+
+REPO_LOCATION=$1
+YAML_CONFIG=$2
+
+test -n "$REPO_LOCATION"
+test -n "$YAML_CONFIG"
 
 # Activate virtual env
 source /gpfs/mindphidata/fongc2/miniconda3/etc/profile.d/conda.sh
@@ -15,8 +18,6 @@ cd ../utils
 
 # Get variables
 SCRIPT="save_anchor_dates.py"
-#YAML_CONFIG="${REPO_LOCATION}cdm-cbioportal-etl/config/etl_config_all_impact.yml"
 
 # Run script
 python $SCRIPT --config_yaml=$YAML_CONFIG
-

--- a/pipeline/bash/bash_summary_creator.sh
+++ b/pipeline/bash/bash_summary_creator.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-#REPO_LOCATION="/gpfs/mindphidata/cdm_repos/github/"
-#YAML_CONFIG="/gpfs/mindphidata/cdm_repos/github/cdm-cbioportal-etl/config/etl_config_mskimpact.yml"
-
 set -e
+
+REPO_LOCATION=$1
+YAML_CONFIG=$2
+
+test -n "$REPO_LOCATION"
+test -n "$YAML_CONFIG"
 
 # Activate virtual env
 source /gpfs/mindphidata/fongc2/miniconda3/etc/profile.d/conda.sh
@@ -14,10 +17,7 @@ cd $MY_PATH
 cd ../summary
 
 # Get variables
-#SCRIPT=$(python -c "from msk_cdm.data_classes.legacy import CDMProcessingVariablesCbioportal as config_cbio_etl; print (${VAR_SCRIPT})")
 SCRIPT=wrapper_cbioportal_summary_creator.py
-#YAML_CONFIG="${REPO_LOCATION}cdm-cbioportal-etl/config/etl_config_mskimpact.yml"
 
 # Run script
 python $SCRIPT --config_yaml=$YAML_CONFIG
-

--- a/pipeline/bash/bash_summary_overall_survival.sh
+++ b/pipeline/bash/bash_summary_overall_survival.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-#REPO_LOCATION="/gpfs/mindphidata/cdm_repos/github/"
-#YAML_CONFIG="/gpfs/mindphidata/cdm_repos/github/cdm-cbioportal-etl/config/etl_config_mskimpact.yml"
-
 set -e
+
+REPO_LOCATION=$1
+YAML_CONFIG=$2
+
+test -n "$REPO_LOCATION"
+test -n "$YAML_CONFIG"
 
 # Activate virtual env
 source /gpfs/mindphidata/fongc2/miniconda3/etc/profile.d/conda.sh
@@ -17,4 +20,3 @@ SCRIPT="cbioportal_overall_survival.py"
 
 # Run script
 python $SCRIPT --config_yaml=$YAML_CONFIG
-

--- a/pipeline/bash/bash_summary_templates.sh
+++ b/pipeline/bash/bash_summary_templates.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
-#YAML_CONFIG="/gpfs/mindphidata/cdm_repos/github/cdm-cbioportal-etl/config/etl_config_mskimpact.yml"
-
 set -e
+
+REPO_LOCATION=$1
+YAML_CONFIG=$2
+
+test -n "$REPO_LOCATION"
+test -n "$YAML_CONFIG"
 
 # Activate virtual env
 source /gpfs/mindphidata/fongc2/miniconda3/etc/profile.d/conda.sh
@@ -12,14 +16,11 @@ MY_PATH="$(dirname -- "${BASH_SOURCE[0]}")"
 cd $MY_PATH
 cd ../utils
 
-
 # Get variables
 SCRIPT="generate_cbioportal_template.py"
-#YAML_CONFIG="${REPO_LOCATION}cdm-cbioportal-etl/config/etl_config_all_impact.yml"
 
 echo "YAML CONFIG: "
 echo $YAML_CONFIG
 
 # Run script
 python $SCRIPT --config_yaml=$YAML_CONFIG
-

--- a/pipeline/bash/bash_timeline_deidentify.sh
+++ b/pipeline/bash/bash_timeline_deidentify.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 
-#REPO_LOCATION="/gpfs/mindphidata/cdm_repos/github/"
-#YAML_CONFIG="/gpfs/mindphidata/cdm_repos/github/cdm-cbioportal-etl/config/etl_config_mskimpact.yml"
-
 set -e
+
+REPO_LOCATION=$1
+YAML_CONFIG=$2
+
+test -n "$REPO_LOCATION"
+test -n "$YAML_CONFIG"
 
 # Activate virtual env
 source /gpfs/mindphidata/fongc2/miniconda3/etc/profile.d/conda.sh
@@ -14,13 +17,10 @@ cd $MY_PATH
 cd ../timeline
 
 # Get variables
-#SCRIPT=$(python -c "from msk_cdm.data_classes.legacy import CDMProcessingVariablesCbioportal as config_cbio_etl; print (${VAR_SCRIPT})")
 SCRIPT="cbioportal_timeline_deid.py"
-#YAML_CONFIG="${REPO_LOCATION}cdm-cbioportal-etl/config/etl_config_all_impact.yml"
 
 echo $SCRIPT
 echo $YAML_CONFIG
 
 # Run script
 python $SCRIPT --config_yaml=$YAML_CONFIG
-

--- a/pipeline/bash/bash_timeline_followup.sh
+++ b/pipeline/bash/bash_timeline_followup.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
 
-#REPO_LOCATION="/gpfs/mindphidata/cdm_repos/github/"
-
 set -e
+
+REPO_LOCATION=$1
+YAML_CONFIG=$2
+
+test -n "$REPO_LOCATION"
+test -n "$YAML_CONFIG"
 
 # Activate virtual env
 source /gpfs/mindphidata/fongc2/miniconda3/etc/profile.d/conda.sh
 conda activate conda-env-cdm
 
 # Get variables
-#SCRIPT=$(python -c "from msk_cdm.data_classes.legacy import CDMProcessingVariablesCbioportal as config_cbio_etl; print (${VAR_SCRIPT})")
 SCRIPT="${REPO_LOCATION}cdm-cbioportal-etl/pipeline/timeline/cbioportal_timeline_follow_up.py"
-#YAML_CONFIG="${REPO_LOCATION}cdm-cbioportal-etl/config/etl_config_all_impact.yml"
 
 # Run script
 python $SCRIPT --config_yaml=$YAML_CONFIG
-

--- a/s3-tasks/s3_pull.sh
+++ b/s3-tasks/s3_pull.sh
@@ -2,6 +2,12 @@
 set -eE -v
 trap 'echo "Last command exited with status code of $?, exiting..."' ERR
 
+SCRIPTS_PATH=$1
+CLUSTER_NAME=$2
+BUCKET_NAME=$3
+SAMPLE_FILEPATH=$4
+OUTPUT_DIR=$5
+
 test -n "$SCRIPTS_PATH"
 test -n "$CLUSTER_NAME"
 test -n "$BUCKET_NAME"

--- a/s3-tasks/s3_push.sh
+++ b/s3-tasks/s3_push.sh
@@ -2,7 +2,14 @@
 set -eE -v
 trap 'echo "Last command exited with status code of $?, exiting..."' ERR
 
+SCRIPTS_PATH=$1
+CLUSTER_NAME=$2
+BUCKET_NAME=$3
+INPUT_DIR=$4
+OUTPUT_DIR=$5
+
 test -n "$SCRIPTS_PATH"
+test -n "$CLUSTER_NAME"
 test -n "$BUCKET_NAME"
 test -n "$INPUT_DIR"
 test -n "$OUTPUT_DIR"


### PR DESCRIPTION
Modify scripts to accept command-line arguments instead of env vars. This will eliminate the need to set the ACCEPT_ENV parameter in sshd_config file on HPC3.