### PR TITLE
Remove references to hard-coded vars from source code

### DIFF
--- a/pipeline/monitoring/monitoring_completeness.py
+++ b/pipeline/monitoring/monitoring_completeness.py
@@ -79,10 +79,23 @@ if __name__ == "__main__":
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--path_datahub",
+        action="store",
+        dest="path_datahub",
+        help="Path to datahub",
+    )
+    parser.add_argument(
+        "--path_minio",
+        action="store",
+        dest="path_minio_cbio",
+        help="Path to minio",
+    )
+
     args = parser.parse_args()
 
     obj_yaml = cbioportal_update_config(fname_yaml_config=args.config_yaml)
-    dict_files_to_copy = obj_yaml.return_dict_datahub_to_minio()
+    dict_files_to_copy = obj_yaml.return_dict_datahub_to_minio(path_datahub=args.path_datahub, path_minio=args.path_minio)
 
     test = monitor_completeness(
         incomplete_fields_csv=args.incomplete_fields_csv,

--- a/pipeline/summary/cbioportal_overall_survival.py
+++ b/pipeline/summary/cbioportal_overall_survival.py
@@ -17,7 +17,8 @@ COL_P_ID = 'PATIENT_ID'
 
 def _load_data(
     obj_minio,
-    fname_demo
+    fname_demo,
+    fname_minio_env
 ):
     # Demographics
     print('Loading %s' % fname_demo)
@@ -26,7 +27,7 @@ def _load_data(
     df_demo = df_demo.drop_duplicates()
 
     # Pathology table for sequencing date
-    df_path_g = get_anchor_dates()
+    df_path_g = get_anchor_dates(fname_minio_env)
     print(df_path_g.head())
 
     print('Data loaded')
@@ -80,7 +81,8 @@ def _process_data(
     # Load data
     df_demo, df_path_g = _load_data(
         obj_minio=obj_minio,
-        fname_demo=fname_demo
+        fname_demo=fname_demo,
+        fname_minio_env=fname_minio_env
     )
     
     # Clean and merge data
@@ -112,16 +114,22 @@ def main():
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="--location of Minio environment file",
+    )
     args = parser.parse_args()
 
     obj_yaml = cbioportal_update_config(fname_yaml_config=args.config_yaml)
-    fname_minio_env = obj_yaml.return_credential_filename()
 
     fname_save = cdm_files.fname_overall_survival
     fname_demo = cdm_files.fname_demo
     
     df_os_f = _process_data(
-        fname_minio_env=fname_minio_env,
+        fname_minio_env=args.minio_env,
         fname_save=fname_save,
         fname_demo=fname_demo
     )

--- a/pipeline/summary/wrapper_cbioportal_summary_creator.py
+++ b/pipeline/summary/wrapper_cbioportal_summary_creator.py
@@ -5,21 +5,15 @@ Create summary files and corresponding headers from CDM data,
 then combine into a single file to be pushed to cbioportal
 
 """
-import os
 import argparse
-from pathlib import Path
-
-import pandas as pd
 
 from cdm_cbioportal_etl.summary import cbioportalSummaryFileCombiner
 from cdm_cbioportal_etl.summary import RedcapToCbioportalFormat
 from cdm_cbioportal_etl.utils import cbioportal_update_config
-from msk_cdm.databricks import DatabricksAPI
 
 
 def create_cbioportal_summary(
     fname_minio_env,
-    dict_databricks,
     patient_or_sample,
     fname_manifest, 
     fname_summary_template,
@@ -70,33 +64,43 @@ def main():
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    parser.add_argument(
+        "--path_datahub",
+        action="store",
+        dest="path_datahub",
+        required=True,
+        help="Path to datahub",
+    )
     args = parser.parse_args()
 
     obj_yaml = cbioportal_update_config(fname_yaml_config=args.config_yaml)
-    fname_minio_env = obj_yaml.return_credential_filename()
     path_minio_summary_intermediate = obj_yaml.return_intermediate_folder_path()
     # fname_meta_data = obj_yaml.return_filename_codebook_metadata()
     # fname_meta_project = obj_yaml.return_filename_codebook_projects()
     # fname_meta_table = obj_yaml.return_filename_codebook_tables()
     production_or_test = obj_yaml.return_production_or_test_indicator()
 
-    # Databricks configs
-    dict_databricks = obj_yaml.return_databricks_configs()
 
     fname_manifest_patient = obj_yaml.return_manifest_filename_patient()
     fname_summary_template_patient = obj_yaml.return_template_info()['fname_p_sum_template_cdsi']
-    fname_summary_patient = obj_yaml.return_filenames_deid_datahub()['summary_patient']
+    fname_summary_patient = obj_yaml.return_filenames_deid_datahub(path_datahub=args.path_datahub)['summary_patient']
 
     fname_manifest_sample = obj_yaml.return_manifest_filename_sample()
     fname_summary_template_sample = obj_yaml.return_template_info()['fname_s_sum_template_cdsi']
-    fname_summary_sample = obj_yaml.return_filenames_deid_datahub()['summary_sample']
+    fname_summary_sample = obj_yaml.return_filenames_deid_datahub(path_datahub=args.path_datahub)['summary_sample']
 
 
     # Create patient summary
     patient_or_sample = 'patient'
     create_cbioportal_summary(
-        fname_minio_env=fname_minio_env,
-        dict_databricks=dict_databricks,
+        fname_minio_env=args.minio_env,
         patient_or_sample=patient_or_sample,
         fname_manifest=fname_manifest_patient,
         fname_summary_template=fname_summary_template_patient,
@@ -106,14 +110,12 @@ def main():
         # fname_meta_data = fname_meta_data,
         # fname_meta_table = fname_meta_table,
         # fname_meta_project = fname_meta_project
-
     )
 
     # Create sample summary
     patient_or_sample = 'sample'
     create_cbioportal_summary(
-        fname_minio_env = fname_minio_env,
-        dict_databricks=dict_databricks,
+        fname_minio_env = args.minio_env,
         patient_or_sample=patient_or_sample,
         fname_manifest=fname_manifest_sample,
         fname_summary_template=fname_summary_template_sample,
@@ -127,6 +129,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    
-    
-  

--- a/pipeline/timeline/cbioportal_timeline_deid.py
+++ b/pipeline/timeline/cbioportal_timeline_deid.py
@@ -36,19 +36,41 @@ def main():
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="location of Minio environment file",
+    )
+    parser.add_argument(
+        "--cbio_sample_list",
+        action="store",
+        dest="cbio_sample_list",
+        required=True,
+        help="location of sample list file",
+    )
+    parser.add_argument(
+        "--path_datahub",
+        action="store",
+        dest="path_datahub",
+        required=True,
+        help="path to datahub",
+    )
+
     args = parser.parse_args()
 
     obj_yaml = cbioportal_update_config(fname_yaml_config=args.config_yaml)
-    DICT_FILES_TIMELINE = obj_yaml.return_dict_phi_to_deid_timeline_production()
-    DICT_FILES_TIMELINE_TESTING = obj_yaml.return_dict_phi_to_deid_timeline_testing()
+    DICT_FILES_TIMELINE = obj_yaml.return_dict_phi_to_deid_timeline_production(path_datahub=args.path_datahub)
+    DICT_FILES_TIMELINE_TESTING = obj_yaml.return_dict_phi_to_deid_timeline_testing(path_datahub=args.path_datahub)
     fname_metadata = obj_yaml.return_filename_codebook_metadata()
     fname_tables = obj_yaml.return_filename_codebook_tables()
-    ENV_MINIO = obj_yaml.return_credential_filename()
+    ENV_MINIO = args.minio_env
     production_or_test = obj_yaml.return_production_or_test_indicator()
     fname_demo = cdm_files.fname_demo
 
     # Get list of sample and patient IDs used for cbioportal ETL
-    fname_sample = obj_yaml.return_sample_list_filename()
+    fname_sample = args.cbio_sample_list
     df_samples_used = pd.read_csv(fname_sample, sep='\t')
     list_dmp_ids = list(df_samples_used['PATIENT_ID'].drop_duplicates())
     list_sample_ids = list(df_samples_used['SAMPLE_ID'].drop_duplicates())

--- a/pipeline/timeline/cbioportal_timeline_follow_up.py
+++ b/pipeline/timeline/cbioportal_timeline_follow_up.py
@@ -31,12 +31,11 @@ rep_dict = {
 def cbioportal_timeline_follow_up(
         yaml_config,
         fname_demo,
-        fname_save
+        fname_save,
+        fname_minio_env
 ):
     print('Parsing config file %s' % yaml_config)
     obj_yaml = cbioportal_update_config(fname_yaml_config=yaml_config)
-    fname_minio_env = obj_yaml.return_credential_filename()
-
 
     ## Create timeline file for follow-up
     ### Load data
@@ -89,6 +88,13 @@ if __name__ == "__main__":
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="--location of Minio environment file",
+    )
     args = parser.parse_args()
 
     fname_demo = cdm_files.fname_demo
@@ -97,5 +103,6 @@ if __name__ == "__main__":
     cbioportal_timeline_follow_up(
         yaml_config=args.config_yaml,
         fname_demo=fname_demo,
-        fname_save=fname_fu_save
+        fname_save=fname_fu_save,
+        fname_minio_env=args.minio_env
     )

--- a/pipeline/utils/generate_age_at_sequencing.py
+++ b/pipeline/utils/generate_age_at_sequencing.py
@@ -15,18 +15,23 @@ if __name__ == "__main__":
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="--location of Minio environment file",
+    )
     args = parser.parse_args()
 
     obj_yaml = cbioportal_update_config(fname_yaml_config=args.config_yaml)
-    fname_minio_env = obj_yaml.return_credential_filename()
 
     fname_demo = config_cdm.fname_demo
     fname_samples = config_cdm.fname_path_clean
 
     compute_age_at_sequencing(
-        minio_env=fname_minio_env,
+        minio_env=args.minio_env,
         fname_demo=fname_demo,
         fname_samples=fname_samples,
         fname_save_age_at_seq=fname_save_age_at_seq
     )
-

--- a/pipeline/utils/generate_cbioportal_template.py
+++ b/pipeline/utils/generate_cbioportal_template.py
@@ -24,10 +24,31 @@ if __name__ == "__main__":
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="--location of Minio environment file",
+    )
+    parser.add_argument(
+        "--cbio_sample_list",
+        action="store",
+        dest="cbio_sample_list",
+        required=True,
+        help="location of sample list file",
+    )
+    parser.add_argument(
+        "--sample_exclude_list",
+        action="store",
+        dest="sample_exclude_list",
+        required=True,
+        help="location of sample exclusion list file",
+    )
+
     args = parser.parse_args()
 
     obj_yaml = cbioportal_update_config(fname_yaml_config=args.config_yaml)
-    fname_minio_env = obj_yaml.return_credential_filename()
 
     fname_summary_header_template_patient = obj_yaml.return_template_info()['fname_cbio_header_template_p']
     fname_summary_template_patient = obj_yaml.return_template_info()['fname_p_sum_template_cdsi']
@@ -35,13 +56,11 @@ if __name__ == "__main__":
     fname_summary_header_template_sample = obj_yaml.return_template_info()['fname_cbio_header_template_s']
     fname_summary_template_sample = obj_yaml.return_template_info()['fname_s_sum_template_cdsi']
 
-    FNAME_SAMPLE_REMOVE = obj_yaml.return_sample_exclude_list()
-    FNAME_CBIO_SID = obj_yaml.return_sample_list_filename()
-
-
+    FNAME_SAMPLE_REMOVE = args.sample_exclude_list
+    FNAME_CBIO_SID = args.cbio_sample_list
 
     cbioportal_template_generator(
-        env_minio=fname_minio_env,
+        env_minio=args.minio_env,
         path_header_sample=fname_summary_header_template_sample,
         path_header_patient=fname_summary_header_template_patient,
         fname_cbio_sid=FNAME_CBIO_SID,

--- a/pipeline/utils/generate_date_of_sequencing.py
+++ b/pipeline/utils/generate_date_of_sequencing.py
@@ -21,18 +21,22 @@ if __name__ == "__main__":
         dest="fname_save_date_of_seq",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="--location of Minio environment file",
+    )
     args = parser.parse_args()
 
     fname_save_date_of_seq = args.fname_save_date_of_seq
     obj_yaml = cbioportal_update_config(fname_yaml_config=args.config_yaml)
-    fname_minio_env = obj_yaml.return_credential_filename()
 
     fname_samples = config_cdm.fname_path_clean
 
     date_of_sequencing(
-        minio_env=fname_minio_env,
+        minio_env=args.minio_env,
         fname_samples=fname_samples,
         fname_save_date_of_seq=fname_save_date_of_seq
     )
-
-

--- a/pipeline/utils/save_anchor_dates.py
+++ b/pipeline/utils/save_anchor_dates.py
@@ -23,7 +23,7 @@ def save_anchor_dates(fname_minio_env, fname_save):
     obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
 
     # Anchor dates
-    df_path_g = get_anchor_dates()
+    df_path_g = get_anchor_dates(fname_minio_env)
 
     print('Saving anchor dates: %s' % fname_save)
     # Save dataframe
@@ -44,14 +44,20 @@ if __name__ == "__main__":
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="--location of Minio environment file",
+    )
     args = parser.parse_args()
 
     obj_yaml = cbioportal_update_config(fname_yaml_config=args.config_yaml)
-    fname_minio_env = obj_yaml.return_credential_filename()
     fname_save = FNAME_SAVE_ANCHOR_DATES
 
     args = parser.parse_args()
     save_anchor_dates(
-        fname_minio_env=fname_minio_env,
+        fname_minio_env=args.minio_env,
         fname_save=fname_save
     )

--- a/pipeline/utils/wrapper_cbioportal_copy_to_databricks.py
+++ b/pipeline/utils/wrapper_cbioportal_copy_to_databricks.py
@@ -46,21 +46,19 @@ def copy_files(
     return None
 
 
-def transfer_to_databricks(config_yaml):
+def transfer_to_databricks(config_yaml, fname_minio_env, databricks_config, catalog, schema, volume, sep, overwrite):
     print('Using config file: %s:' % config_yaml)
     obj_yaml = cbioportal_update_config(fname_yaml_config=config_yaml)
-
-    fname_minio_env = obj_yaml.return_credential_filename()
 
     fname_codebook_tables = obj_yaml.return_filename_codebook_tables()
     df_codebook_tables = pd.read_csv(fname_codebook_tables, sep=',')
     list_minio = list(df_codebook_tables.loc[df_codebook_tables['copy_to_databricks'].notnull(), 'cdm_source_table'])
 
+    # TODO idk about this
     # Databricks configs
     dict_databricks = obj_yaml.return_databricks_configs()
     print(dict_databricks)
     # Databricks processing for saving data
-    fname_databricks_env = dict_databricks['fname_databricks_config']
     catalog = dict_databricks['catalog']
     schema = dict_databricks['schema']
     volume = dict_databricks['volume']
@@ -70,9 +68,8 @@ def transfer_to_databricks(config_yaml):
     dir_volume = os.path.join('/Volumes',catalog,schema,volume)
 
     # Setup MinIO
-    obj_db = DatabricksAPI(fname_databricks_env=fname_databricks_env)
+    obj_db = DatabricksAPI(fname_databricks_env=databricks_config)
     obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
-
 
     # Copy files
     for i,fname_source in enumerate(list_minio):
@@ -108,6 +105,21 @@ if __name__ == "__main__":
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="--location of Minio environment file",
+    )
+    parser.add_argument(
+        "--databricks_config",
+        action="store",
+        dest="databricks_config",
+        required=True,
+        help="--location of Databricks config file",
+    )
+
     args = parser.parse_args()
 
-    transfer_to_databricks(config_yaml=args.config_yaml)
+    transfer_to_databricks(config_yaml=args.config_yaml, fname_minio_env=args.minio_env)

--- a/pipeline/utils/wrapper_cbioportal_copy_to_minio.py
+++ b/pipeline/utils/wrapper_cbioportal_copy_to_minio.py
@@ -14,11 +14,10 @@ def copy_files(obj_minio, fname_source, dest_path_object):
     
     return None
 
-def transfer_to_minio(config_yaml):
+def transfer_to_minio(config_yaml, fname_minio_env, path_datahub, path_minio):
 
     obj_yaml = cbioportal_update_config(fname_yaml_config=config_yaml)
-    dict_files_to_copy = obj_yaml.return_dict_datahub_to_minio()
-    fname_minio_env = obj_yaml.return_credential_filename()
+    dict_files_to_copy = obj_yaml.return_dict_datahub_to_minio(path_datahub=path_datahub, path_minio=path_minio)
 
     # Setup MinIO
     obj_minio = MinioAPI(
@@ -43,6 +42,31 @@ if __name__ == "__main__":
         dest="config_yaml",
         help="Yaml file containing run parameters and necessary file locations.",
     )
+    parser.add_argument(
+        "--minio_env",
+        action="store",
+        dest="minio_env",
+        required=True,
+        help="Location of Minio environment file",
+    )
+    parser.add_argument(
+        "--path_minio",
+        action="store",
+        dest="path_minio",
+        required=True,
+        help="Path to MinIO files",
+    )
+    parser.add_argument(
+        "--path_datahub",
+        action="store",
+        dest="path_datahub",
+        required=True,
+        help="Path to Datahub",
+    )
+
     args = parser.parse_args()
 
-    transfer_to_minio(config_yaml=args.config_yaml)
+    transfer_to_minio(config_yaml=args.config_yaml,
+                      fname_minio_env=args.minio_env,
+                      path_datahub=args.path_datahub,
+                      path_minio=args.path_minio)

--- a/src/cdm_cbioportal_etl/summary/create_summary_from_redcap_reports.py
+++ b/src/cdm_cbioportal_etl/summary/create_summary_from_redcap_reports.py
@@ -76,7 +76,7 @@ class RedcapToCbioportalFormat(object):
         )
         
         # Load anchor data containing data to deidentify tables
-        self._df_anchor = get_anchor_dates()
+        self._df_anchor = get_anchor_dates(self._fname_minio_env)
         
         df_metadata, df_tables, df_project = self.init_metadata()
         self._df_metadata = df_metadata

--- a/src/cdm_cbioportal_etl/timeline/cbioportal_timeline_deid_files.py
+++ b/src/cdm_cbioportal_etl/timeline/cbioportal_timeline_deid_files.py
@@ -65,7 +65,7 @@ def cbioportal_deid_timeline_files(
     :param dict_files_timeline: Dictionary of cbioportal formatted timeline file names to load (containing PHI) and corresponding filenames of files to be pushed to cbioportal
     :return: None
     """
-    df_path_g = get_anchor_dates()
+    df_path_g = get_anchor_dates(fname_minio_env)
     obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
 
     df_os = process_df_os(

--- a/src/cdm_cbioportal_etl/utils/age_at_sequencing.py
+++ b/src/cdm_cbioportal_etl/utils/age_at_sequencing.py
@@ -59,7 +59,7 @@ def compute_age_at_sequencing(
     df_path = mrn_zero_pad(df=df_path, col_mrn='MRN')
 
     ## Load anchor dates
-    df_archor_dates = get_anchor_dates()
+    df_archor_dates = get_anchor_dates(minio_env)
     list_sample_ids_used = list(set(df_archor_dates['DMP_ID']))
 
     # Clean and Combine data

--- a/src/cdm_cbioportal_etl/utils/cbioportal_update_config.py
+++ b/src/cdm_cbioportal_etl/utils/cbioportal_update_config.py
@@ -171,7 +171,7 @@ class CbioportalUpdateConfig(object):
 
         return template_files
 
-    def return_dict_datahub_to_minio(self):
+    def return_dict_datahub_to_minio(self, path_datahub, path_minio):
         """
         Map DataHub and MinIO filenames and return a dictionary of the mapped paths.
 
@@ -184,9 +184,6 @@ class CbioportalUpdateConfig(object):
         deid_filenames = list(config.get('deid_filenames', {}).values())
         list_deid_files = deid_filenames + list_timeline_files
 
-        path_datahub = config.get('inputs', {}).get('path_datahub')
-        path_minio = config.get('inputs', {}).get('path_minio_cbio')
-
         list_deid_files_datahub = [os.path.join(path_datahub,x) for x in list_deid_files]
         list_deid_files_minio = [os.path.join(path_minio,x) for x in list_deid_files]
 
@@ -194,7 +191,7 @@ class CbioportalUpdateConfig(object):
 
         return dict_datahub_to_minio
 
-    def return_dict_phi_to_deid_timeline_production(self) -> dict:
+    def return_dict_phi_to_deid_timeline_production(self, path_datahub) -> dict:
         """
         Map template files to actual filenames using the 'template_files' section
         of the YAML file and the mapping from the loaded codebook table.
@@ -211,7 +208,6 @@ class CbioportalUpdateConfig(object):
         """
         config = self._config
 
-        path_datahub = config.get('inputs', {}).get('path_datahub')
         codebook_table = self._df_codebook_table
         df_codebook_timeline_prod = codebook_table[codebook_table['cbio_timeline_file_production'] == 'x'].copy()
         df_timeline_files = df_codebook_timeline_prod[['cdm_source_table', 'cbio_deid_filename']].dropna()
@@ -221,7 +217,7 @@ class CbioportalUpdateConfig(object):
 
         return dict_phi_to_deid_timeline
 
-    def return_dict_phi_to_deid_timeline_testing(self) -> dict:
+    def return_dict_phi_to_deid_timeline_testing(self, path_datahub) -> dict:
         """
         Map template files to actual filenames using the 'template_files' section
         of the YAML file and the mapping from the loaded codebook table. (Testing study)
@@ -238,7 +234,6 @@ class CbioportalUpdateConfig(object):
         """
         config = self._config
 
-        path_datahub = config.get('inputs', {}).get('path_datahub')
         codebook_table = self._df_codebook_table
         df_codebook_timeline_prod = codebook_table[codebook_table['cbio_timeline_file_testing'] == 'x'].copy()
         df_timeline_files = df_codebook_timeline_prod[['cdm_source_table', 'cbio_deid_filename']].dropna()
@@ -248,12 +243,11 @@ class CbioportalUpdateConfig(object):
 
         return dict_phi_to_deid_timeline
 
-    def return_filenames_deid_datahub(self) -> dict:
+    def return_filenames_deid_datahub(self, path_datahub) -> dict:
         config = self._config
 
-        path_datahub_root = config.get('inputs', {}).get('path_datahub')
         files = config.get('deid_filenames', {})
-        joined_paths_dict = {key: os.path.join(path_datahub_root, filename) for key, filename in files.items()}
+        joined_paths_dict = {key: os.path.join(path_datahub, filename) for key, filename in files.items()}
 
         return joined_paths_dict
 

--- a/src/cdm_cbioportal_etl/utils/get_anchor_dates.py
+++ b/src/cdm_cbioportal_etl/utils/get_anchor_dates.py
@@ -5,7 +5,6 @@ from msk_cdm.data_classes.epic_ddp_concat import CDMProcessingVariables as c_var
 from msk_cdm.minio import MinioAPI
 from msk_cdm.data_processing import set_debug_console, mrn_zero_pad
 
-FNAME_MINIO_ENV = c_var.minio_env
 FNAME_PATHOLOGY = c_var.fname_id_map
 COLS_PATHOLOGY = [
     'MRN',
@@ -15,9 +14,9 @@ COLS_PATHOLOGY = [
 ]
 
 
-def get_anchor_dates():
+def get_anchor_dates(fname_minio_env):
     print('Creating anchor date table from first sequencing date..')
-    obj_minio = MinioAPI(fname_minio_env=FNAME_MINIO_ENV)
+    obj_minio = MinioAPI(fname_minio_env=fname_minio_env)
     
     print('Loading %s' % FNAME_PATHOLOGY)
     obj = obj_minio.load_obj(path_object=FNAME_PATHOLOGY)


### PR DESCRIPTION
To-do:
- [ ] Modify `pipeline/utils/wrapper_cbioportal_copy_to_databricks.py` `return_databricks_configs()` function
- [ ] Codebook path and references in `cbioportal_update_config.py`
- [ ] Remove the hard-coded paths from all the configs and commit after above changes